### PR TITLE
preventing a crash during layout where next item is out of bounds for…

### DIFF
--- a/Classes/CSStickyHeaderFlowLayout.m
+++ b/Classes/CSStickyHeaderFlowLayout.m
@@ -198,7 +198,13 @@ NSString *const CSStickyHeaderParallaxHeader = @"CSStickyHeaderParallexHeader";
     
     if (nextItem < items) {
         NSIndexPath *nextIndexPath = [NSIndexPath indexPathForItem:nextItem inSection:indexPath.section];
-        CGRect nextFrame = [super layoutAttributesForItemAtIndexPath:nextIndexPath].frame;
+        CGRect nextFrame = currentFrame;
+        @try {
+            nextFrame = [super layoutAttributesForItemAtIndexPath:nextIndexPath].frame;
+        }
+        @catch (NSException *ex) {
+            nextFrame = currentFrame;
+        }
         nextFrame.origin.y += self.parallaxHeaderReferenceSize.height;
         
         CGRect shiftedNextFrame = CGRectMake(floorf(CGRectGetMinX(currentFrame)),


### PR DESCRIPTION
… the item array.

0  CoreFoundation                 0x184aa822c __exceptionPreprocess
1  libobjc.A.dylib                0x1967740e4 objc_exception_throw
2  CoreFoundation                 0x18498b4fc -[__NSArrayM removeObjectAtIndex:]
3  UIKit                          0x189beb8b8 -[_UIFlowLayoutSection frameForItemAtIndexPath:]
4  UIKit                          0x189bc1dc4 -[UICollectionViewFlowLayout _frameForItem:inSection:usingData:]
5  UIKit                          0x189bc0108 -[UICollectionViewFlowLayout layoutAttributesForItemAtIndexPath:usingData:]
6  Bodybuilding.com Store         0x1008d2c64 -[CSStickyHeaderFlowLayout layoutAttributesForItemAtIndexPath:](CSStickyHeaderFlowLayout.m:201)
7  Bodybuilding.com Store         0x1008d23e0 __62-[CSStickyHeaderFlowLayout layoutAttributesForElementsInRect:]_block_invoke (CSStickyHeaderFlowLayout.m:67)
8  CoreFoundation                 0x18499cd48 __53-[__NSArrayM enumerateObjectsWithOptions:usingBlock:]_block_invoke
9  CoreFoundation                 0x18499cc2c -[__NSArrayM enumerateObjectsWithOptions:usingBlock:]
10 APP         0x1008d1d40 -[CSStickyHeaderFlowLayout layoutAttributesForElementsInRect:](CSStickyHeaderFlowLayout.m:53)
11 UIKit                          0x189582c10 __45-[UICollectionViewData validateLayoutInRect:]_block_invoke
12 UIKit                          0x189582654 -[UICollectionViewData validateLayoutInRect:]
